### PR TITLE
[TS-000] Work around report / examples / fixes

### DIFF
--- a/examples/pprof/main.go
+++ b/examples/pprof/main.go
@@ -1,21 +1,12 @@
 package main
 
 import (
-	"github.com/cryptopay-dev/yaga/errors"
-	"github.com/cryptopay-dev/yaga/logger/nop"
 	"github.com/cryptopay-dev/yaga/pprof"
-	"github.com/cryptopay-dev/yaga/web"
+	"github.com/labstack/echo"
 )
 
 func main() {
-	e := web.New(web.Options{
-		Logger: nop.New(),
-		Error: errors.Logic{errors.Options{
-			Logger: nop.New(),
-		}},
-	})
-
+	e := echo.New()
 	pprof.Wrap(e)
-
 	e.Start(":8080")
 }

--- a/examples/report/main.go
+++ b/examples/report/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/cryptopay-dev/yaga/errors"
+	"github.com/cryptopay-dev/yaga/logger/nop"
+	"github.com/cryptopay-dev/yaga/report"
+	"github.com/cryptopay-dev/yaga/web"
+)
+
+func main() {
+	e := web.New(web.Options{
+		Logger: nop.New(),
+		Error: errors.Logic{Opts: errors.Options{
+			Logger: nop.New(),
+		}},
+	})
+
+	e.GET("/", func(ctx web.Context) error {
+		ts := time.Now()
+
+		// Variant 1:
+		defer report.CaptureResponseTimings(
+			ctx.Response(),
+			ctx.Path(),
+			time.Now(),
+		)
+
+		// Variant 2:
+		defer report.CaptureResponseTime(
+			"some-platform",
+			"some-action",
+			time.Now(),
+		)
+
+		// Capture margin:
+		defer report.CaptureMargin(
+			"some-platform",
+			"some-pair",
+			float64(time.Since(ts)),
+		)
+
+		return ctx.String(
+			http.StatusOK,
+			"OK",
+		)
+	})
+
+	if err := e.Start(":8080"); err != nil {
+		panic(err)
+	}
+}

--- a/report/report.go
+++ b/report/report.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/cryptopay-dev/go-metrics"
+	"github.com/labstack/echo"
 )
 
 // CaptureResponseTime used to track response timing
@@ -14,6 +15,22 @@ func CaptureResponseTime(platform, action string, now time.Time) {
 		"platform": platform,
 		"action":   action,
 	}, "exchange_timings")
+}
+
+// CaptureResponseTimings used to track response code, endpoint and timing
+func CaptureResponseTimings(res *echo.Response, endpoint string, now time.Time) {
+	var code int
+
+	if res != nil {
+		code = res.Status
+	}
+
+	metrics.SendWithTags(metrics.M{
+		"response_ns":   time.Since(now).Seconds() * 1e3,
+		"response_code": code,
+	}, metrics.T{
+		"endpoint": endpoint,
+	}, "response")
 }
 
 // CaptureMargin used to track margin for pair


### PR DESCRIPTION
- fix pprof - simplify
- add report examples
- rename report/main.go -> report/report.go
- add CaptureResponseTimings for capture response code, endpoint and timing