### PR TITLE
[TS-000] Custom Bind + Errors formatter

### DIFF
--- a/web/bind.go
+++ b/web/bind.go
@@ -1,0 +1,238 @@
+package web
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"net/http"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/labstack/echo"
+)
+
+type (
+	// DefaultBinder is the default implementation of the Binder interface.
+	DefaultBinder struct{}
+)
+
+// Bind implements the `Binder#Bind` function.
+func (b *DefaultBinder) Bind(i interface{}, c Context) (err error) {
+	req := c.Request()
+	if req.ContentLength == 0 {
+		if req.Method == "GET" || req.Method == "DELETE" {
+			if err = b.bindData(i, c.QueryParams(), "query"); err != nil {
+				return NewHTTPError(http.StatusBadRequest, err.Error())
+			}
+			return
+		}
+		return NewHTTPError(http.StatusBadRequest, "Request body can't be empty")
+	}
+	ctype := req.Header.Get(echo.HeaderContentType)
+	switch {
+	case strings.HasPrefix(ctype, echo.MIMEApplicationJSON):
+		if err = json.NewDecoder(req.Body).Decode(i); err != nil {
+			return err
+		}
+	case strings.HasPrefix(ctype, echo.MIMEApplicationXML), strings.HasPrefix(ctype, echo.MIMETextXML):
+		if err = xml.NewDecoder(req.Body).Decode(i); err != nil {
+			return err
+		}
+	case strings.HasPrefix(ctype, echo.MIMEApplicationForm), strings.HasPrefix(ctype, echo.MIMEMultipartForm):
+		params, err := c.FormParams()
+		if err != nil {
+			return err
+		}
+		if err = b.bindData(i, params, "form"); err != nil {
+			return err
+		}
+	default:
+		return ErrUnsupportedMediaType
+	}
+	return
+}
+
+func (b *DefaultBinder) bindData(ptr interface{}, data map[string][]string, tag string) error {
+	typ := reflect.TypeOf(ptr).Elem()
+	val := reflect.ValueOf(ptr).Elem()
+
+	if typ.Kind() != reflect.Struct {
+		return NewHTTPError(http.StatusBadRequest, "binding element must be a struct")
+	}
+
+	for i := 0; i < typ.NumField(); i++ {
+		typeField := typ.Field(i)
+		structField := val.Field(i)
+		if !structField.CanSet() {
+			continue
+		}
+		structFieldKind := structField.Kind()
+		inputFieldName := typeField.Tag.Get(tag)
+
+		if inputFieldName == "" {
+			inputFieldName = typeField.Name
+			// If tag is nil, we inspect if the field is a struct.
+			if _, ok := bindUnmarshaler(structField); !ok && structFieldKind == reflect.Struct {
+				err := b.bindData(structField.Addr().Interface(), data, tag)
+				if err != nil {
+					return err
+				}
+				continue
+			}
+		}
+		inputValue, exists := data[inputFieldName]
+		if !exists {
+			continue
+		}
+
+		// Call this first, in case we're dealing with an alias to an array type
+		if ok, err := unmarshalField(typeField.Type.Kind(), inputValue[0], structField); ok {
+			if err != nil {
+				return err
+			}
+			continue
+		}
+
+		numElems := len(inputValue)
+		if structFieldKind == reflect.Slice && numElems > 0 {
+			sliceOf := structField.Type().Elem().Kind()
+			slice := reflect.MakeSlice(structField.Type(), numElems, numElems)
+			for j := 0; j < numElems; j++ {
+				if err := setWithProperType(sliceOf, inputValue[j], slice.Index(j)); err != nil {
+					return err
+				}
+			}
+			val.Field(i).Set(slice)
+		} else {
+			if err := setWithProperType(typeField.Type.Kind(), inputValue[0], structField); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func setWithProperType(valueKind reflect.Kind, val string, structField reflect.Value) error {
+	// But also call it here, in case we're dealing with an array of BindUnmarshalers
+	if ok, err := unmarshalField(valueKind, val, structField); ok {
+		return err
+	}
+
+	switch valueKind {
+	case reflect.Ptr:
+		return setWithProperType(structField.Elem().Kind(), val, structField.Elem())
+	case reflect.Int:
+		return setIntField(val, 0, structField)
+	case reflect.Int8:
+		return setIntField(val, 8, structField)
+	case reflect.Int16:
+		return setIntField(val, 16, structField)
+	case reflect.Int32:
+		return setIntField(val, 32, structField)
+	case reflect.Int64:
+		return setIntField(val, 64, structField)
+	case reflect.Uint:
+		return setUintField(val, 0, structField)
+	case reflect.Uint8:
+		return setUintField(val, 8, structField)
+	case reflect.Uint16:
+		return setUintField(val, 16, structField)
+	case reflect.Uint32:
+		return setUintField(val, 32, structField)
+	case reflect.Uint64:
+		return setUintField(val, 64, structField)
+	case reflect.Bool:
+		return setBoolField(val, structField)
+	case reflect.Float32:
+		return setFloatField(val, 32, structField)
+	case reflect.Float64:
+		return setFloatField(val, 64, structField)
+	case reflect.String:
+		structField.SetString(val)
+	default:
+		return NewHTTPError(http.StatusBadRequest, "unknown type")
+	}
+	return nil
+}
+
+func unmarshalField(valueKind reflect.Kind, val string, field reflect.Value) (bool, error) {
+	switch valueKind {
+	case reflect.Ptr:
+		return unmarshalFieldPtr(val, field)
+	default:
+		return unmarshalFieldNonPtr(val, field)
+	}
+}
+
+// bindUnmarshaler attempts to unmarshal a reflect.Value into a BindUnmarshaler
+func bindUnmarshaler(field reflect.Value) (echo.BindUnmarshaler, bool) {
+	ptr := reflect.New(field.Type())
+	if ptr.CanInterface() {
+		iface := ptr.Interface()
+		if unmarshaler, ok := iface.(echo.BindUnmarshaler); ok {
+			return unmarshaler, ok
+		}
+	}
+	return nil, false
+}
+
+func unmarshalFieldNonPtr(value string, field reflect.Value) (bool, error) {
+	if unmarshaler, ok := bindUnmarshaler(field); ok {
+		err := unmarshaler.UnmarshalParam(value)
+		field.Set(reflect.ValueOf(unmarshaler).Elem())
+		return true, err
+	}
+	return false, nil
+}
+
+func unmarshalFieldPtr(value string, field reflect.Value) (bool, error) {
+	if field.IsNil() {
+		// Initialize the pointer to a nil value
+		field.Set(reflect.New(field.Type().Elem()))
+	}
+	return unmarshalFieldNonPtr(value, field.Elem())
+}
+
+func setIntField(value string, bitSize int, field reflect.Value) error {
+	if value == "" {
+		value = "0"
+	}
+	intVal, err := strconv.ParseInt(value, 10, bitSize)
+	if err == nil {
+		field.SetInt(intVal)
+	}
+	return err
+}
+
+func setUintField(value string, bitSize int, field reflect.Value) error {
+	if value == "" {
+		value = "0"
+	}
+	uintVal, err := strconv.ParseUint(value, 10, bitSize)
+	if err == nil {
+		field.SetUint(uintVal)
+	}
+	return err
+}
+
+func setBoolField(value string, field reflect.Value) error {
+	if value == "" {
+		value = "false"
+	}
+	boolVal, err := strconv.ParseBool(value)
+	if err == nil {
+		field.SetBool(boolVal)
+	}
+	return err
+}
+
+func setFloatField(value string, bitSize int, field reflect.Value) error {
+	if value == "" {
+		value = "0.0"
+	}
+	floatVal, err := strconv.ParseFloat(value, bitSize)
+	if err == nil {
+		field.SetFloat(floatVal)
+	}
+	return err
+}

--- a/web/bind_test.go
+++ b/web/bind_test.go
@@ -1,0 +1,345 @@
+package web
+
+import (
+	"bytes"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	userJSON       = `{"id":1,"name":"Jon Snow"}`
+	userXML        = `<user><id>1</id><name>Jon Snow</name></user>`
+	userForm       = `id=1&name=Jon Snow`
+	invalidContent = "invalid content"
+)
+
+type (
+	user struct {
+		ID   int    `json:"id" xml:"id" form:"id" query:"id"`
+		Name string `json:"name" xml:"name" form:"name" query:"name"`
+	}
+
+	bindTestStruct struct {
+		I           int
+		PtrI        *int
+		I8          int8
+		PtrI8       *int8
+		I16         int16
+		PtrI16      *int16
+		I32         int32
+		PtrI32      *int32
+		I64         int64
+		PtrI64      *int64
+		UI          uint
+		PtrUI       *uint
+		UI8         uint8
+		PtrUI8      *uint8
+		UI16        uint16
+		PtrUI16     *uint16
+		UI32        uint32
+		PtrUI32     *uint32
+		UI64        uint64
+		PtrUI64     *uint64
+		B           bool
+		PtrB        *bool
+		F32         float32
+		PtrF32      *float32
+		F64         float64
+		PtrF64      *float64
+		S           string
+		PtrS        *string
+		cantSet     string
+		DoesntExist string
+		T           Timestamp
+		Tptr        *Timestamp
+		SA          StringArray
+	}
+	Timestamp   time.Time
+	StringArray []string
+	Struct      struct {
+		Foo string
+	}
+)
+
+func (t *Timestamp) UnmarshalParam(src string) error {
+	ts, err := time.Parse(time.RFC3339, src)
+	*t = Timestamp(ts)
+	return err
+}
+
+func (a *StringArray) UnmarshalParam(src string) error {
+	*a = StringArray(strings.Split(src, ","))
+	return nil
+}
+
+func (s *Struct) UnmarshalParam(src string) error {
+	*s = Struct{
+		Foo: src,
+	}
+	return nil
+}
+
+func (t bindTestStruct) GetCantSet() string {
+	return t.cantSet
+}
+
+var values = map[string][]string{
+	"I":       {"0"},
+	"PtrI":    {"0"},
+	"I8":      {"8"},
+	"PtrI8":   {"8"},
+	"I16":     {"16"},
+	"PtrI16":  {"16"},
+	"I32":     {"32"},
+	"PtrI32":  {"32"},
+	"I64":     {"64"},
+	"PtrI64":  {"64"},
+	"UI":      {"0"},
+	"PtrUI":   {"0"},
+	"UI8":     {"8"},
+	"PtrUI8":  {"8"},
+	"UI16":    {"16"},
+	"PtrUI16": {"16"},
+	"UI32":    {"32"},
+	"PtrUI32": {"32"},
+	"UI64":    {"64"},
+	"PtrUI64": {"64"},
+	"B":       {"true"},
+	"PtrB":    {"true"},
+	"F32":     {"32.5"},
+	"PtrF32":  {"32.5"},
+	"F64":     {"64.5"},
+	"PtrF64":  {"64.5"},
+	"S":       {"test"},
+	"PtrS":    {"test"},
+	"cantSet": {"test"},
+	"T":       {"2016-12-06T19:09:05+01:00"},
+	"Tptr":    {"2016-12-06T19:09:05+01:00"},
+	"ST":      {"bar"},
+}
+
+func TestBindJSON(t *testing.T) {
+	testBindOkay(t, strings.NewReader(userJSON), echo.MIMEApplicationJSON)
+	testBindError(t, strings.NewReader(invalidContent), echo.MIMEApplicationJSON)
+}
+
+func TestBindXML(t *testing.T) {
+	testBindOkay(t, strings.NewReader(userXML), echo.MIMEApplicationXML)
+	testBindError(t, strings.NewReader(invalidContent), echo.MIMEApplicationXML)
+	testBindOkay(t, strings.NewReader(userXML), echo.MIMETextXML)
+	testBindError(t, strings.NewReader(invalidContent), echo.MIMETextXML)
+}
+
+func TestBindForm(t *testing.T) {
+	testBindOkay(t, strings.NewReader(userForm), echo.MIMEApplicationForm)
+	testBindError(t, nil, echo.MIMEApplicationForm)
+	e := echo.New()
+	req := httptest.NewRequest(echo.POST, "/", strings.NewReader(userForm))
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationForm)
+	err := c.Bind(&[]struct{ Field string }{})
+	assert.Error(t, err)
+}
+
+func TestBindQueryParams(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(echo.GET, "/?id=1&name=Jon+Snow", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	u := new(user)
+	err := c.Bind(u)
+	if assert.NoError(t, err) {
+		assert.Equal(t, 1, u.ID)
+		assert.Equal(t, "Jon Snow", u.Name)
+	}
+}
+
+func TestBindUnmarshalParam(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(echo.GET, "/?ts=2016-12-06T19:09:05Z&sa=one,two,three&ta=2016-12-06T19:09:05Z&ta=2016-12-06T19:09:05Z&ST=baz", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	result := struct {
+		T  Timestamp   `query:"ts"`
+		TA []Timestamp `query:"ta"`
+		SA StringArray `query:"sa"`
+		ST Struct
+	}{}
+	err := c.Bind(&result)
+	ts := Timestamp(time.Date(2016, 12, 6, 19, 9, 5, 0, time.UTC))
+	if assert.NoError(t, err) {
+		//		assert.Equal(t, Timestamp(reflect.TypeOf(&Timestamp{}), time.Date(2016, 12, 6, 19, 9, 5, 0, time.UTC)), result.T)
+		assert.Equal(t, ts, result.T)
+		assert.Equal(t, StringArray([]string{"one", "two", "three"}), result.SA)
+		assert.Equal(t, []Timestamp{ts, ts}, result.TA)
+		assert.Equal(t, Struct{"baz"}, result.ST)
+	}
+}
+
+func TestBindUnmarshalParamPtr(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(echo.GET, "/?ts=2016-12-06T19:09:05Z", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	result := struct {
+		Tptr *Timestamp `query:"ts"`
+	}{}
+	err := c.Bind(&result)
+	if assert.NoError(t, err) {
+		assert.Equal(t, Timestamp(time.Date(2016, 12, 6, 19, 9, 5, 0, time.UTC)), *result.Tptr)
+	}
+}
+
+func TestBindMultipartForm(t *testing.T) {
+	body := new(bytes.Buffer)
+	mw := multipart.NewWriter(body)
+	mw.WriteField("id", "1")
+	mw.WriteField("name", "Jon Snow")
+	mw.Close()
+	testBindOkay(t, body, mw.FormDataContentType())
+}
+
+func TestBindUnsupportedMediaType(t *testing.T) {
+	testBindError(t, strings.NewReader(invalidContent), echo.MIMEApplicationJSON)
+}
+
+func TestBindbindData(t *testing.T) {
+	ts := new(bindTestStruct)
+	b := new(DefaultBinder)
+	b.bindData(ts, values, "form")
+	assertBindTestStruct(t, ts)
+}
+
+func TestBindSetWithProperType(t *testing.T) {
+	ts := new(bindTestStruct)
+	typ := reflect.TypeOf(ts).Elem()
+	val := reflect.ValueOf(ts).Elem()
+	for i := 0; i < typ.NumField(); i++ {
+		typeField := typ.Field(i)
+		structField := val.Field(i)
+		if !structField.CanSet() {
+			continue
+		}
+		if len(values[typeField.Name]) == 0 {
+			continue
+		}
+		val := values[typeField.Name][0]
+		err := setWithProperType(typeField.Type.Kind(), val, structField)
+		assert.NoError(t, err)
+	}
+	assertBindTestStruct(t, ts)
+
+	type foo struct {
+		Bar bytes.Buffer
+	}
+	v := &foo{}
+	typ = reflect.TypeOf(v).Elem()
+	val = reflect.ValueOf(v).Elem()
+	assert.Error(t, setWithProperType(typ.Field(0).Type.Kind(), "5", val.Field(0)))
+}
+
+func TestBindSetFields(t *testing.T) {
+	ts := new(bindTestStruct)
+	val := reflect.ValueOf(ts).Elem()
+	// Int
+	if assert.NoError(t, setIntField("5", 0, val.FieldByName("I"))) {
+		assert.Equal(t, 5, ts.I)
+	}
+	if assert.NoError(t, setIntField("", 0, val.FieldByName("I"))) {
+		assert.Equal(t, 0, ts.I)
+	}
+
+	// Uint
+	if assert.NoError(t, setUintField("10", 0, val.FieldByName("UI"))) {
+		assert.Equal(t, uint(10), ts.UI)
+	}
+	if assert.NoError(t, setUintField("", 0, val.FieldByName("UI"))) {
+		assert.Equal(t, uint(0), ts.UI)
+	}
+
+	// Float
+	if assert.NoError(t, setFloatField("15.5", 0, val.FieldByName("F32"))) {
+		assert.Equal(t, float32(15.5), ts.F32)
+	}
+	if assert.NoError(t, setFloatField("", 0, val.FieldByName("F32"))) {
+		assert.Equal(t, float32(0.0), ts.F32)
+	}
+
+	// Bool
+	if assert.NoError(t, setBoolField("true", val.FieldByName("B"))) {
+		assert.Equal(t, true, ts.B)
+	}
+	if assert.NoError(t, setBoolField("", val.FieldByName("B"))) {
+		assert.Equal(t, false, ts.B)
+	}
+
+	ok, err := unmarshalFieldNonPtr("2016-12-06T19:09:05Z", val.FieldByName("T"))
+	if assert.NoError(t, err) {
+		assert.Equal(t, ok, true)
+		assert.Equal(t, Timestamp(time.Date(2016, 12, 6, 19, 9, 5, 0, time.UTC)), ts.T)
+	}
+}
+
+func assertBindTestStruct(t *testing.T, ts *bindTestStruct) {
+	assert.Equal(t, 0, ts.I)
+	assert.Equal(t, int8(8), ts.I8)
+	assert.Equal(t, int16(16), ts.I16)
+	assert.Equal(t, int32(32), ts.I32)
+	assert.Equal(t, int64(64), ts.I64)
+	assert.Equal(t, uint(0), ts.UI)
+	assert.Equal(t, uint8(8), ts.UI8)
+	assert.Equal(t, uint16(16), ts.UI16)
+	assert.Equal(t, uint32(32), ts.UI32)
+	assert.Equal(t, uint64(64), ts.UI64)
+	assert.Equal(t, true, ts.B)
+	assert.Equal(t, float32(32.5), ts.F32)
+	assert.Equal(t, float64(64.5), ts.F64)
+	assert.Equal(t, "test", ts.S)
+	assert.Equal(t, "", ts.GetCantSet())
+}
+
+func testBindOkay(t *testing.T, r io.Reader, ctype string) {
+	e := echo.New()
+	req := httptest.NewRequest(echo.POST, "/", r)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	req.Header.Set(echo.HeaderContentType, ctype)
+	u := new(user)
+	err := c.Bind(u)
+	if assert.NoError(t, err) {
+		assert.Equal(t, 1, u.ID)
+		assert.Equal(t, "Jon Snow", u.Name)
+	}
+}
+
+func testBindError(t *testing.T, r io.Reader, ctype string) {
+	e := echo.New()
+	req := httptest.NewRequest(echo.POST, "/", r)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	req.Header.Set(echo.HeaderContentType, ctype)
+	u := new(user)
+	err := c.Bind(u)
+
+	switch {
+	case strings.HasPrefix(ctype, echo.MIMEApplicationJSON), strings.HasPrefix(ctype, echo.MIMEApplicationXML), strings.HasPrefix(ctype, echo.MIMETextXML),
+		strings.HasPrefix(ctype, echo.MIMEApplicationForm), strings.HasPrefix(ctype, echo.MIMEMultipartForm):
+		if assert.IsType(t, new(echo.HTTPError), err) {
+			assert.Equal(t, http.StatusBadRequest, err.(*echo.HTTPError).Code)
+		}
+	default:
+		if assert.IsType(t, new(echo.HTTPError), err) {
+			assert.Equal(t, ErrUnsupportedMediaType, err)
+		}
+	}
+}

--- a/web/web.go
+++ b/web/web.go
@@ -102,6 +102,8 @@ func New(opts Options) *Engine {
 		e.Validator = opts.Validator
 	}
 
+	e.Binder = new(DefaultBinder)
+
 	if opts.Error != nil {
 		e.HTTPErrorHandler = opts.Error.Capture
 		e.Use(opts.Error.Recover())


### PR DESCRIPTION
Example:

```
→ curl -i -H "User-agent: Midas Ruby client v0.5.0" -H "Content-type: application/json;charset=UTF-8" -H "Accept: application/json;charset=UTF-8" -H "Accept-charset: UTF-8" -d "pair=BTCEUR&amount=1000&action=sell&currency=EUR&expire=1000" -X POST 'http://localhost:8081/quotes'
HTTP/1.1 400 Bad Request
Content-Type: application/json; charset=UTF-8
X-Ray-Trace-Id: d4e52452-1759-4a5b-ad46-33545c872b20
Date: Thu, 01 Mar 2018 11:47:11 GMT
Content-Length: 134

{
  "error": "JSON parse error: offset=1, error=invalid character 'p' looking for beginning of value",
  "stack": [],
  "result": []
}
```