### PR TITLE
[GO-000] Local metrics

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,12 @@
 
 
 [[projects]]
+  branch = "master"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
+
+[[projects]]
   name = "github.com/bsm/redis-lock"
   packages = ["."]
   revision = "1dfc459b28b179b4ff73d82b7b58d8d2b10ec3be"
@@ -87,6 +93,12 @@
   version = "v6.10.2"
 
 [[projects]]
+  name = "github.com/golang/protobuf"
+  packages = ["proto"]
+  revision = "925541529c1fa6821df4e44ce2723319eb2be768"
+  version = "v1.0.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/golang/sync"
   packages = ["errgroup"]
@@ -166,6 +178,12 @@
   version = "v0.0.3"
 
 [[projects]]
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  revision = "3247c84500bff8d9fb6d579d800f20b3e091582c"
+  version = "v1.0.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
@@ -204,6 +222,42 @@
   packages = ["difflib"]
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/prometheus/client_golang"
+  packages = [
+    "prometheus",
+    "prometheus/promhttp"
+  ]
+  revision = "c5b7fccd204277076155f10851dad72b76a49317"
+  version = "v0.8.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/common"
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model"
+  ]
+  revision = "38c53a9f4bfcd932d1b00bfc65e256a7fba6b37a"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/procfs"
+  packages = [
+    ".",
+    "internal/util",
+    "nfs",
+    "xfs"
+  ]
+  revision = "780932d4fbbe0e69b84c34c20f5c8d0981e109ea"
 
 [[projects]]
   name = "github.com/robfig/cron"
@@ -356,6 +410,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f4b7c2f46e6725bd4a2242f6e88b025dcbc5d526d105686d1d5487bd226435ef"
+  inputs-digest = "f0d1d9a035880b604136da24b6021fca75bb8cf620e858c12b98963c85a3240b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -1,0 +1,32 @@
+package prometheus
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/cryptopay-dev/yaga/logger/log"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+//ErrBadPrometheusBind to serve metrics
+var ErrBadPrometheusBind = errors.New("check prometheus bind address")
+
+// Serve prometheus metrics
+func Serve() error {
+	bind := os.Getenv("PROMETHEUS")
+
+	if len(bind) == 0 {
+		return ErrBadPrometheusBind
+	}
+
+	go func() {
+		log.Debugf("run prometheus metrics on `%s`", bind)
+
+		if err := http.ListenAndServe(bind, promhttp.Handler()); err != nil {
+			log.Panic(errors.Wrap(err, "can't serve prometheus metrics"))
+		}
+	}()
+
+	return nil
+}

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -1,0 +1,31 @@
+package prometheus
+
+import (
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServe(t *testing.T) {
+	t.Run("no address", func(t *testing.T) {
+		if err := os.Setenv("PROMETHEUS", ""); err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Error(t, Serve())
+	})
+
+	t.Run("ok address", func(t *testing.T) {
+		server := httptest.NewServer(nil)
+		bind := server.Listener.Addr().String()
+		server.Close()
+
+		if err := os.Setenv("PROMETHEUS", bind); err != nil {
+			t.Fatal(err)
+		}
+
+		assert.NoError(t, Serve())
+	})
+}


### PR DESCRIPTION
Example of docker-compose.yml:

```yaml
version: '2.3'

services:

  grafana:
    image: grafana/grafana
    ports:
      - 3000:3000
  
  prometheus:
    image: prom/prometheus
    ports:
      - 9090:9090
    volumes:
      - ./prometheus.yml:/etc/prometheus/prometheus.yml
```

Example of prometheus.yml:

```yaml
global:
  scrape_interval: 15s
  scrape_timeout: 10s
  evaluation_interval: 15s
alerting:
  alertmanagers:
  - static_configs:
    - targets: []
    scheme: http
    timeout: 10s
scrape_configs:
- job_name: prometheus
  scrape_interval: 15s
  scrape_timeout: 10s
  metrics_path: /metrics
  scheme: http
  static_configs:
  - targets:
    - localhost:9090
- job_name: moron
  scrape_interval: 15s
  scrape_timeout: 10s
  metrics_path: /
  scheme: http
  static_configs:
  - targets:
    - YOUR_LOCAL_IP:PROMETHEUS_METRICS_PORT
```

ENV:

```
PROMETHEUS=PROMETHEUS_METRICS_PORT go run main.go
```