### PR TITLE
Metrics

### DIFF
--- a/examples/metrics/main.go
+++ b/examples/metrics/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/cryptopay-dev/yaga/logger/log"
+	"github.com/cryptopay-dev/yaga/metrics"
+	"github.com/cryptopay-dev/yaga/metrics/prometheus"
+)
+
+func main() {
+	addr := ":18080"
+
+	log.Info("Create prometheus metrics provider")
+	provider := prometheus.NewProvider(addr)
+
+	log.Info("Setup metrics provider")
+	metrics.SetProvider(provider)
+
+	log.Infof("Starting prometheus web server with address: %s", addr)
+	provider.StartWebServer()
+
+	log.Info("Write `example_counter` counter, increase to 5")
+	metrics.IncrementCounter("example_counter", 5)
+
+	log.Info("Write `example_gauage` gauage, increase to 5")
+	metrics.IncrementGauge("example_gauage", 5)
+
+	log.Info("Write `example_gauage` gauage, decrease to 3")
+	metrics.IncrementGauge("example_gauage", -2)
+
+	log.Info("Write `example_summary` summary, write 1s value")
+	metrics.Observe("example_summary", time.Second.Seconds())
+
+	log.Infof("Open %s and check metrics values", addr)
+
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+	<-ch
+
+	log.Info("Gotten stop signal")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	log.Info("Shutdown prometheus web server with 1s timeout")
+	err := provider.StopWebServer(ctx)
+	log.Info("Stop prometheus web server return error: %s", err)
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,35 @@
+package metrics
+
+// Provider interface describe all accessible variants for to write metrics
+type Provider interface {
+	// IncrementCounter increase counter metric,
+	// a counter is a cumulative metric that represents a single numerical value that only ever goes up
+	IncrementCounter(key string, value uint)
+	// IncrementGauge add value to gauge metric,
+	// a gauge is a metric that represents a single numerical value that can arbitrarily go up and down
+	IncrementGauge(key string, value int)
+	// Observe write new value to summaray metric
+	Observe(key string, value float64)
+}
+
+var defaultProvider Provider
+
+// SetProvider set global metrics provider
+func SetProvider(p Provider) {
+	defaultProvider = p
+}
+
+// IncrementCounter increase key counter
+func IncrementCounter(key string, value uint) {
+	defaultProvider.IncrementCounter(key, value)
+}
+
+// IncrementGauge add value to gauge by key
+func IncrementGauge(key string, value int) {
+	defaultProvider.IncrementGauge(key, value)
+}
+
+// Observe write new value to summaray metric
+func Observe(key string, value float64) {
+	defaultProvider.Observe(key, value)
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -12,7 +12,7 @@ type Provider interface {
 	Observe(key string, value float64)
 }
 
-var defaultProvider Provider
+var defaultProvider Provider = &nop{}
 
 // SetProvider set global metrics provider
 func SetProvider(p Provider) {

--- a/metrics/nop.go
+++ b/metrics/nop.go
@@ -1,0 +1,7 @@
+package metrics
+
+type nop struct{}
+
+func (n nop) IncrementCounter(key string, value uint) {}
+func (n nop) IncrementGauge(key string, value int)    {}
+func (n nop) Observe(key string, value float64)       {}

--- a/metrics/prometheus/provider.go
+++ b/metrics/prometheus/provider.go
@@ -1,0 +1,71 @@
+package prometheus
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// Provider is addapter from prometheus client to metrics.Provider interface
+type Provider struct {
+	server *http.Server
+
+	Counter *prometheus.CounterVec
+	Gauge   *prometheus.GaugeVec
+	Summary *prometheus.SummaryVec
+}
+
+// NewProvider yield new prometheus providert instance
+func NewProvider(bindAddress string) *Provider {
+	p := &Provider{
+		server: &http.Server{
+			Addr:    bindAddress,
+			Handler: promhttp.Handler(),
+		},
+
+		Counter: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: "app_counters",
+				Help: "is common counter metrics with different `key` label",
+			},
+			[]string{"key"},
+		),
+		Gauge: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "app_gauages",
+				Help: "is common gauage metrics with different `key` label",
+			},
+			[]string{"key"},
+		),
+		Summary: prometheus.NewSummaryVec(
+			prometheus.SummaryOpts{
+				Name:       "app_summaries",
+				Help:       "is common summary metrics with different `key` label",
+				Objectives: map[float64]float64{0.5: 0.5, 0.75: 0.75, 0.95: 0.95, 0.99: 0.99},
+			},
+			[]string{"key"},
+		),
+	}
+
+	prometheus.Register(p.Counter)
+	prometheus.Register(p.Gauge)
+	prometheus.Register(p.Summary)
+
+	return p
+}
+
+// IncrementCounter increase key counter
+func (p Provider) IncrementCounter(key string, value uint) {
+	p.Counter.WithLabelValues(key).Add(float64(value))
+}
+
+// IncrementGauge add value to gauge by key
+func (p Provider) IncrementGauge(key string, value int) {
+	p.Gauge.WithLabelValues(key).Add(float64(value))
+}
+
+// Observe write new value to summaray metric
+func (p Provider) Observe(key string, value float64) {
+	p.Summary.WithLabelValues(key).Observe(value)
+}

--- a/metrics/prometheus/server.go
+++ b/metrics/prometheus/server.go
@@ -1,0 +1,24 @@
+package prometheus
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/cryptopay-dev/yaga/logger/log"
+)
+
+// StartWebServer run http server in separate goroutine
+func (p *Provider) StartWebServer() {
+	go func() {
+		if err := p.server.ListenAndServe(); err != nil {
+			if err != http.ErrServerClosed {
+				log.Errorw("start prometheus http server error", "error", err)
+			}
+		}
+	}()
+}
+
+// StopWebServer calling http.Server.Shutdown
+func (p *Provider) StopWebServer(ctx context.Context) error {
+	return p.server.Shutdown(ctx)
+}


### PR DESCRIPTION
## Description

* `metrics` - pkg with common interface for metrics collectors  systems;
* `metrics/prometheus` - [prometheus](https://prometheus.io/docs/) implementation for metrics

## Example

```
≻ go run examples/metrics/main.go
2018-04-11T16:50:58.274+0300	INFO	metrics/main.go:18	Create prometheus metrics provider
2018-04-11T16:50:58.274+0300	INFO	metrics/main.go:21	Setup metrics provider
2018-04-11T16:50:58.274+0300	INFO	metrics/main.go:24	Starting prometheus web server with address: :18080
2018-04-11T16:50:58.274+0300	INFO	metrics/main.go:27	Write `example_counter` counter, increase to 5
2018-04-11T16:50:58.274+0300	INFO	metrics/main.go:30	Write `example_gauage` gauage, increase to 5
2018-04-11T16:50:58.274+0300	INFO	metrics/main.go:33	Write `example_gauage` gauage, decrease to 3
2018-04-11T16:50:58.274+0300	INFO	metrics/main.go:36	Write `example_summary` summary, write 1s value
2018-04-11T16:50:58.274+0300	INFO	metrics/main.go:39	Open :18080 and check metrics values


≻ curl -s http://127.0.0.1:18080 | head -n 15
# HELP app_counters is common counter metrics with different `key` label
# TYPE app_counters counter
app_counters{key="example_counter"} 5
# HELP app_gauages is common gauage metrics with different `key` label
# TYPE app_gauages gauge
app_gauages{key="example_gauage"} 3
# HELP app_summaries is common summary metrics with different `key` label
# TYPE app_summaries summary
app_summaries{key="example_summary",quantile="0.5"} 1
app_summaries{key="example_summary",quantile="0.75"} 1
app_summaries{key="example_summary",quantile="0.95"} 1
app_summaries{key="example_summary",quantile="0.99"} 1
app_summaries_sum{key="example_summary"} 1
app_summaries_count{key="example_summary"} 1
# HELP go_gc_duration_seconds A summary of the GC invocation durations.
```